### PR TITLE
powerups-fix: change powerups timing and overlapping

### DIFF
--- a/src/states/game.ts
+++ b/src/states/game.ts
@@ -123,7 +123,7 @@ export default class Title extends Phaser.State {
 
         this.game.physics.arcade.collide(this.player, this.enemyBullets, this.bulletHitPlayer);
         for (let powerup of this.powerups) {
-            if (powerup.is_alive) {
+            if (powerup.powerup_not_activated) {
                 this.game.physics.arcade.collide(this.player, powerup, this.applyPowerup);
             }
         }
@@ -148,7 +148,7 @@ export default class Title extends Phaser.State {
         let row_height = 20;
         let active_powerups = '';
         for (let powerup of this.powerups) {
-            if (powerup.time_left > 1) {
+            if (powerup.time_left > 0) {
                 active_powerups = ' ' + powerup.power_type + ': ' + powerup.time_left;
                 let y = origin_y + active_count * row_height;
                 active_count++;
@@ -168,6 +168,10 @@ export default class Title extends Phaser.State {
 
     public getEnemies() {
         return this.enemies;
+    }
+
+    public getPowerups() {
+        return this.powerups;
     }
 
     public addSpawnedObject(obj: Phaser.Sprite): Phaser.State {

--- a/src/states/survival.ts
+++ b/src/states/survival.ts
@@ -51,7 +51,7 @@ export default class SurvivalTitle extends Title {
 
         this.game.physics.arcade.collide(this.player, this.enemyBullets, this.bulletHitPlayer);
         for (let powerup of this.powerups) {
-            if (powerup.is_alive) {
+            if (powerup.powerup_not_activated) {
                 this.game.physics.arcade.collide(this.player, powerup, this.applyPowerup);
             }
         }


### PR DESCRIPTION
First off, sorry if this should have been an issue we could discuss upon. We can close this PR and I'll open an issue and discuss options like we did for menu backgrounds.
What I did: until this change, our powerups worked like:
When powerup is activated, we post an event to be called each second until `time_left == 0`. We additionally post an event for first `time_left` seconds to deactivate the powerup.
There are two problems with this approach:
1. the event called each second could have delays of some 100 - 200 - 300 ms (or even more, if system running game is not for gaming). These delays would add up and it could show that you have 2 more seconds of powerup, when in reality it's just expiring.
2. in case of powerups overlapping, the second type of event would have cancelled the powerup effect, even if a second powerup of same type was activated in the mean time. 
E.g:
Say at second 10 of game player activates Missiles. They should have double damage until second 20 of game. 
Then at second 15 player activates another Missiles powerup. They expect double damage continue until second 25 of game.
What happens is expiration of event for first Powerup will restore damage at second 20, even if in UI it shows the second Powerup still have 5 seconds left.

What I changed:
In the first issue, i used `(new DateTime()).now()` to set `start_time` and based on that value the `end_time`. This should happen for all powerups. The first type of event is now posted every 300 ms to show a more accurate `time_left`. We can decrease the post frequency to increase accuracy. A further improvement would be to figure out if powerup expires on this single type of events, instead of the event with the total duration of powerup, which could also have delays.
In the second problem, when a powerup is activated, all other powerups of same type that were active, are deactivated. They won't show up in the UI either.
I also renamed powerups `is_alive` to `powerup_not_activated`, as it tracks whether the powerup has been activated by player or is just sitting in the field.